### PR TITLE
Update lichess.bib: Amortized Planning with Large-Scale Transformers: A Case Study on Chess

### DIFF
--- a/lichess.bib
+++ b/lichess.bib
@@ -572,12 +572,11 @@
   keywords      = {chess, game playing agents, human-agent play},
 }
 
-@article{ruoss:2024:grandmaster-level-chess-without-search,
-  title         = {Grandmaster-Level Chess Without Search},
-  author        = {Anian Ruoss and Gr{\'{e}}goire Del{\'{e}}tang and Sourabh Medapati and Jordi Grau{-}Moya and Li Kevin Wenliang and Elliot Catt and John Reid and Tim Genewein},
+@inproceedings{ruoss2024amortized,
+  title         = {Amortized Planning with Large-Scale Transformers: A Case Study on Chess},
+  author        = {Anian Ruoss and Gr{\'{e}}goire Del{\'{e}}tang and Sourabh Medapati and Jordi Grau{-}Moya and Li Kevin Wenliang and Elliot Catt and John Reid and Cannada A. Lewis and Joel Veness and Tim Genewein},
   year          = {2024},
-  journal       = {CoRR},
-  volume        = {abs/2402.04494},
+  booktitle     = {NeurIPS},
   doi           = {10.48550/ARXIV.2402.04494},
   url           = {https://doi.org/10.48550/arXiv.2402.04494},
   eprinttype    = {arXiv},


### PR DESCRIPTION
The new version of `Grandmaster-Level Chess Without Search` is `Amortized Planning with Large-Scale Transformers: A Case Study on Chess`. Updating lichess.bib to reflect the change.