### PR TITLE
adding preprint from Steven Pav

### DIFF
--- a/lichess.bib
+++ b/lichess.bib
@@ -1819,3 +1819,13 @@ BibTex
   booktitle     = {{IEEE} International Conference on Big Data, Big Data 2024, Washington DC, USA, December 15-18, 2024},
   publisher     = {{IEEE}},
 }
+
+@misc{pav:2025:inferring-piece-value,
+  title         = {Inferring Piece Value in Chess and Chess Variants},
+  author        = {Steven Pav},
+  year          = {2025},
+  url           = {https://arxiv.org/abs/2509.04691},
+  eprint        = {2509.04691},
+  archiveprefix = {arXiv},
+  primaryclass  = {stat.AP},
+}


### PR DESCRIPTION
New [preprint](https://arxiv.org/abs/2509.04691) on inferring piece value, which uses Lichess data