### PR TITLE
Update code for bread emoji

### DIFF
--- a/lichess.bib
+++ b/lichess.bib
@@ -3342,7 +3342,7 @@
   abstract      = {We detail the bread emoji team's submission to the IEEE BigData 2024 Predicting Chess Puzzle Difficulty Challenge. Our solution revolved around the use of ensembled, pretrained, neural chessboard embedders (specifically, truncated Maia and Leela models) and an empirically-guided distribution rescaling postprocessing step.Our approach was the outright winner of the competition with a >16.4\% reduction in mean squared error (MSE) over second place in the preliminary evaluation and a >13.3\% reduction in MSE over second place in the final evaluation.},
   keywords      = {Training;Transfer learning;Artificial neural networks;Predictive models;Big Data;Data models;Emojis},
   affiliation   = {Google; Tokyo Institute of Technology},
-  code          = {https://github.com/mcognetta/ieee-chess},
+  code          = {https://github.com/mcognetta/ieee-chess/tree/2024-iteration-archive},
 }
 
 @inproceedings{woodruff:2025:bread-emoji-teams-submission-to-2025-fedcsis-predicting-chess-puzzle-difficulty-challenge,
@@ -3359,6 +3359,7 @@
   url           = {http://dx.doi.org/10.15439/2025F6771},
   abstract      = {We detail the bread emoji team's submission to the FedCSIS 2025 Predicting Chess Puzzle Difficulty Challenge. Our solution revolved around improving our submission from the previous competition by incorporating a new puzzle metadata feature and optimizing our implementation to allow for larger model ensembles and more stable training. Similar to our submission from last year, our system has two stages: learning a strong predictor for the Lichess dataset and then rescaling the distribution using an empirically-guided post-processing step to fit it to the smaller and noisier competition dataset. Our submission placed second with a ~3.9\% gap in mean squared error (MSE) from first place in the final evaluation.},
   affiliation   = {Google; Institute of Science Tokyo; Amazon Project Kuiper},
+  code          = {https://github.com/mcognetta/ieee-chess},
 }
 
 @inproceedings{xiao:2025:multi-source-feature-fusion-neural-embedding-for-predicting-chess-puzzle-difficulty,


### PR DESCRIPTION
Both iterations of the bread emoji paper have code, but the 2024 version was moved to an archived branch, while the 2025 version lives in the main branch.